### PR TITLE
Improve Linux Steam support (install detection, "Launch in Steam")

### DIFF
--- a/P2ModLoader/Forms/Tabs/SettingsTab.cs
+++ b/P2ModLoader/Forms/Tabs/SettingsTab.cs
@@ -82,7 +82,6 @@ public class SettingsTab : BaseTab {
 
     private void BrowseButton_Click(object? sender, EventArgs e) {
         using var folderDialog = new FolderBrowserDialog();
-        folderDialog.Description = "Select the location of Pathologic.exe file";
         if (folderDialog.ShowDialog() != DialogResult.OK) return;
         SettingsHolder.InstallPath = folderDialog.SelectedPath;
         _mainForm.UpdateControls();

--- a/P2ModLoader/Forms/Tabs/SettingsTab.cs
+++ b/P2ModLoader/Forms/Tabs/SettingsTab.cs
@@ -82,6 +82,7 @@ public class SettingsTab : BaseTab {
 
     private void BrowseButton_Click(object? sender, EventArgs e) {
         using var folderDialog = new FolderBrowserDialog();
+        folderDialog.Description = "Select the location of Pathologic.exe file";
         if (folderDialog.ShowDialog() != DialogResult.OK) return;
         SettingsHolder.InstallPath = folderDialog.SelectedPath;
         _mainForm.UpdateControls();

--- a/P2ModLoader/Helper/GameLauncher.cs
+++ b/P2ModLoader/Helper/GameLauncher.cs
@@ -75,7 +75,7 @@ namespace P2ModLoader.Helper {
             if (!SettingsHolder.IsPatched && !TryPatch()) return;
             
             var steamProcess = new ProcessStartInfo {
-                FileName = Path.Combine(InstallationLocator.FindSteam()!, "steam.exe"),
+                FileName = Path.Combine(InstallationLocator.FindSteam()!, InstallationLocator.STEAM_EXE),
                 Arguments = "-applaunch 505230 -StraightIntoFreemode"
             };
 

--- a/P2ModLoader/Helper/InstallationLocator.cs
+++ b/P2ModLoader/Helper/InstallationLocator.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using System.Text.RegularExpressions;
 using Microsoft.Win32;
 
@@ -6,11 +7,13 @@ namespace P2ModLoader.Helper;
 public static class InstallationLocator {
     private const string STEAM_32_BIT_PATH = @"SOFTWARE\Valve\Steam";
     private const string STEAM_64_BIT_PATH = @"SOFTWARE\Wow6432Node\Valve\Steam";
+
+    private const string STEAM_LINUX_PATH = @"\.local\share\Steam"; // example: /home/username/.local/share/Steam
     
-    private const string PATHOLOGIC_2_STEAM_APP_ID = "505230";
+    private const string PATHOLOGIC_2_STEAM_APP_ID = "230410";
     
     private const string STEAM_LIBRARY_FOLDERS_PATH = @"config\libraryfolders.vdf";
-    private const string PATHOLOGIC_STEAM_RELATIVE_PATH = @"steamapps\common\Pathologic";
+    private const string PATHOLOGIC_STEAM_RELATIVE_PATH = @"steamapps\common\Warframe";
 
     private const string APPDATA_PATH = @"AppData\LocalLow\Ice-Pick Lodge\Pathologic 2";
     
@@ -20,20 +23,76 @@ public static class InstallationLocator {
 
         return steamPath;
     }
-    
-    public static string? FindInstall() {
+
+    public static string? FindSteamLinux()
+    {
+        if (!Path.Exists(@"Z:\home"))
+        {
+            // Likely not using Wine (i.e. on Windows), or non-standard Wine setup
+            return null;
+        }
+
+        var user = System.Security.Principal.WindowsIdentity.GetCurrent().Name;
+        user = user[(user.LastIndexOf('\\')+1)..]; // "DEVICENAME/username" -> "username"
+
+        var steamPath = Path.Join(@"Z:\home\", user, STEAM_LINUX_PATH);
+        return steamPath;
+    }
+
+    public static string? FindGog()
+    {
+        // TODO
+        Logger.LogWarning("FindGog -- not implemented");
+        var gogPath = "";
+        return gogPath;
+    }
+
+    public static string? FindInstall()
+    {
         var steamPath = FindSteam();
-        
-        // TODO: Handle GOG installs.
-        return string.IsNullOrEmpty(steamPath) ? null : FindSteamInstall(steamPath);
+        if  (!string.IsNullOrEmpty(steamPath))
+        {
+            Logger.LogInfo("Found Steam installation:   " + steamPath);
+            return FindSteamInstall(steamPath);
+        };
+
+
+        steamPath = FindSteamLinux();
+        if (!string.IsNullOrEmpty(steamPath))
+        {
+            Logger.LogInfo("Found Steam installation:   " + steamPath);
+            return FindSteamInstall(steamPath);
+        }
+
+        var gogPath = FindGog();
+        if (!string.IsNullOrEmpty(gogPath))
+        {
+            Logger.LogInfo("Found GOG installation:   " + gogPath);
+            return FindGogInstall(gogPath);
+        }
+
+        return null;
+        }
+
+    private static string? FindGogInstall(string gogPath)
+    {
+        return null;
     }
 
     private static string? FindSteamInstall(string steamPath) {
         var libraryFoldersPath = Path.Combine(steamPath, STEAM_LIBRARY_FOLDERS_PATH);
-        if (!File.Exists(libraryFoldersPath)) return null;
+        Logger.LogInfo("libraryFoldersPath: " + libraryFoldersPath + " ; " + File.Exists(libraryFoldersPath));
+        if (!File.Exists(libraryFoldersPath))
+        {
+            libraryFoldersPath = Path.Combine(steamPath, STEAM_LIBRARY_FOLDERS_PATH.ToLower());
+            if (!File.Exists(libraryFoldersPath))
+            {
+                return null;
+            }
+        }
 
         var installPath = FindPathologicSteamPath(libraryFoldersPath);
-
+        Logger.LogInfo("installPath: " + installPath);
         return installPath;
     }
 
@@ -57,7 +116,9 @@ public static class InstallationLocator {
 
             var pathMatch = pathRegex.Match(line);
             if (pathMatch.Success)
+            {
                 currentPath = pathMatch.Groups[1].Value.Replace(@"\\", @"\");
+            }
 
             if (currentPath != null && appRegex.IsMatch(line)) {
                 foundApp = true;
@@ -70,7 +131,7 @@ public static class InstallationLocator {
 
         if (!foundApp)
             return null;
-        
+
         return currentPath != null ? Path.Combine(currentPath, PATHOLOGIC_STEAM_RELATIVE_PATH) : null;
     }
 

--- a/P2ModLoader/Helper/InstallationLocator.cs
+++ b/P2ModLoader/Helper/InstallationLocator.cs
@@ -1,4 +1,3 @@
-using System.Diagnostics;
 using System.Text.RegularExpressions;
 using Microsoft.Win32;
 
@@ -10,10 +9,10 @@ public static class InstallationLocator {
 
     private const string STEAM_LINUX_PATH = @"\.local\share\Steam"; // example: /home/username/.local/share/Steam
     
-    private const string PATHOLOGIC_2_STEAM_APP_ID = "230410";
+    private const string PATHOLOGIC_2_STEAM_APP_ID = "505230";
     
     private const string STEAM_LIBRARY_FOLDERS_PATH = @"config\libraryfolders.vdf";
-    private const string PATHOLOGIC_STEAM_RELATIVE_PATH = @"steamapps\common\Warframe";
+    private const string PATHOLOGIC_STEAM_RELATIVE_PATH = @"steamapps\common\Pathologic";
 
     private const string APPDATA_PATH = @"AppData\LocalLow\Ice-Pick Lodge\Pathologic 2";
     
@@ -39,14 +38,6 @@ public static class InstallationLocator {
         return steamPath;
     }
 
-    public static string? FindGog()
-    {
-        // TODO
-        Logger.LogWarning("FindGog -- not implemented");
-        var gogPath = "";
-        return gogPath;
-    }
-
     public static string? FindInstall()
     {
         var steamPath = FindSteam();
@@ -64,20 +55,9 @@ public static class InstallationLocator {
             return FindSteamInstall(steamPath);
         }
 
-        var gogPath = FindGog();
-        if (!string.IsNullOrEmpty(gogPath))
-        {
-            Logger.LogInfo("Found GOG installation:   " + gogPath);
-            return FindGogInstall(gogPath);
-        }
-
+        // TODO: Handle GOG installs.
         return null;
         }
-
-    private static string? FindGogInstall(string gogPath)
-    {
-        return null;
-    }
 
     private static string? FindSteamInstall(string steamPath) {
         var libraryFoldersPath = Path.Combine(steamPath, STEAM_LIBRARY_FOLDERS_PATH);
@@ -138,6 +118,7 @@ public static class InstallationLocator {
     public static string? FindAppData() {
         var userPath = Environment.GetEnvironmentVariable("USERPROFILE");
         var appdataPath = Path.Combine(userPath!, APPDATA_PATH);
+        Logger.LogInfo("appdata\n" + userPath + "\n" + appdataPath);
         
         return Directory.Exists(appdataPath) ? appdataPath : null;
     }

--- a/P2ModLoader/Helper/InstallationLocator.cs
+++ b/P2ModLoader/Helper/InstallationLocator.cs
@@ -8,14 +8,14 @@ public static class InstallationLocator {
     private const string STEAM_64_BIT_PATH = @"SOFTWARE\Wow6432Node\Valve\Steam";
 
     private const string STEAM_LINUX_PATH = @"\.local\share\Steam"; // example: /home/username/.local/share/Steam
-    
+
     private const string PATHOLOGIC_2_STEAM_APP_ID = "505230";
-    
+
     private const string STEAM_LIBRARY_FOLDERS_PATH = @"config\libraryfolders.vdf";
     private const string PATHOLOGIC_STEAM_RELATIVE_PATH = @"steamapps\common\Pathologic";
 
     private const string APPDATA_PATH = @"AppData\LocalLow\Ice-Pick Lodge\Pathologic 2";
-    
+
     public static string? FindSteam() {
         var steamPath = GetSteamPathFromRegistry(STEAM_32_BIT_PATH);
         steamPath ??= GetSteamPathFromRegistry(STEAM_64_BIT_PATH);
@@ -23,50 +23,43 @@ public static class InstallationLocator {
         return steamPath;
     }
 
-    public static string? FindSteamLinux()
-    {
-        if (!Path.Exists(@"Z:\home"))
-        {
+    public static string? FindSteamLinux() {
+        if (!Path.Exists(@"Z:\home")) {
             // Likely not using Wine (i.e. on Windows), or non-standard Wine setup
             return null;
         }
 
         var user = System.Security.Principal.WindowsIdentity.GetCurrent().Name;
-        user = user[(user.LastIndexOf('\\')+1)..]; // "DEVICENAME/username" -> "username"
+        user = user[(user.LastIndexOf('\\') + 1)..]; // "DEVICENAME/username" -> "username"
 
         var steamPath = Path.Join(@"Z:\home\", user, STEAM_LINUX_PATH);
         return steamPath;
     }
 
-    public static string? FindInstall()
-    {
+    public static string? FindInstall() {
         var steamPath = FindSteam();
-        if  (!string.IsNullOrEmpty(steamPath))
-        {
+        if (!string.IsNullOrEmpty(steamPath)) {
             Logger.LogInfo("Found Steam installation:   " + steamPath);
             return FindSteamInstall(steamPath);
         };
 
 
         steamPath = FindSteamLinux();
-        if (!string.IsNullOrEmpty(steamPath))
-        {
+        if (!string.IsNullOrEmpty(steamPath)) {
             Logger.LogInfo("Found Steam installation:   " + steamPath);
             return FindSteamInstall(steamPath);
         }
 
         // TODO: Handle GOG installs.
         return null;
-        }
+    }
 
     private static string? FindSteamInstall(string steamPath) {
         var libraryFoldersPath = Path.Combine(steamPath, STEAM_LIBRARY_FOLDERS_PATH);
         Logger.LogInfo("libraryFoldersPath: " + libraryFoldersPath + " ; " + File.Exists(libraryFoldersPath));
-        if (!File.Exists(libraryFoldersPath))
-        {
+        if (!File.Exists(libraryFoldersPath)) {
             libraryFoldersPath = Path.Combine(steamPath, STEAM_LIBRARY_FOLDERS_PATH.ToLower());
-            if (!File.Exists(libraryFoldersPath))
-            {
+            if (!File.Exists(libraryFoldersPath)) {
                 return null;
             }
         }
@@ -95,8 +88,7 @@ public static class InstallationLocator {
             var line = t.Trim();
 
             var pathMatch = pathRegex.Match(line);
-            if (pathMatch.Success)
-            {
+            if (pathMatch.Success) {
                 currentPath = pathMatch.Groups[1].Value.Replace(@"\\", @"\");
             }
 
@@ -119,7 +111,7 @@ public static class InstallationLocator {
         var userPath = Environment.GetEnvironmentVariable("USERPROFILE");
         var appdataPath = Path.Combine(userPath!, APPDATA_PATH);
         Logger.LogInfo("appdata\n" + userPath + "\n" + appdataPath);
-        
+
         return Directory.Exists(appdataPath) ? appdataPath : null;
     }
 }


### PR DESCRIPTION
Overview of changes:
-  FindSteam() function in InstallationLocator.cs will also check for a Linux Steam installation by looking at Z:/ virtual drive, which is present in all standard Wine setups
- Steam executable filename is stored in InstallationLocator.STEAM_EXE var. This is usually `steam.exe`, unless FindSteam actually finds a Linux Steam installation. GameLauncher now uses this variable instead of a hardcoded filename
